### PR TITLE
Force Overwrite

### DIFF
--- a/update
+++ b/update
@@ -46,7 +46,7 @@ if ( $last_revision != $svn_last_revision ) {
 			if ( file_exists( 'plugins/' . $plugin ) )
 				exec( 'rm -rf ' . escapeshellarg( 'plugins/' . $plugin ) );
 
-			exec( 'unzip -d plugins ' . escapeshellarg( 'zips/' . $plugin . '.zip' ) );
+			exec( 'unzip -o -d plugins ' . escapeshellarg( 'zips/' . $plugin . '.zip' ) );
 			exec( 'rm -rf ' . escapeshellarg( 'zips/' . $plugin . '.zip' ) );
 		} else {
 			echo '... download failed.';


### PR DESCRIPTION
This is for issue #5 - It puts a -o in the unzip command to force overwrite any same-named files.
