### PR TITLE
Update estimated size

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,7 +47,7 @@ changed since. Only those changed plugins are updated after the initial sync.
 
 ### How much disk space do I need? ###
 
-As of early 2013, it takes up about 4.1GB.
+As of oktober 2013, it takes up about 10,8GB.
 
 ### Something went wrong, how do I do a partial update? ###
 


### PR DESCRIPTION
It seems like a lot but this is what both Finder and "du -sm plugins" (11028 MB) report.

I don't know where the sudden increase comes from.
