### PR TITLE
Hotfix: Missing variable

### DIFF
--- a/update
+++ b/update
@@ -50,6 +50,7 @@ if ( file_exists( $directory . '/.last-revision' ) ) {
 }
 
 $start_time = time();
+$plugins = array();
 
 if ( $last_revision != $svn_last_revision ) {
 	if ( $last_revision ) {


### PR DESCRIPTION
The source code did not introduce the $plugins variable.
Therefor PHP environments with high error reporting always show notices
which are even send to the sysop via mail when doing cron jobs.
To fix that the variable has been introduced.

Notice send via mail is:


```
PHP Notice:  Undefined variable: plugins in update on line 98
```

