### PR TITLE
Use /usr/bin/env for portability

### DIFF
--- a/download
+++ b/download
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 $args = $argv;
 $cmd = array_shift( $args );

--- a/update
+++ b/update
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 $args = $argv;
 $cmd = array_shift( $args );


### PR DESCRIPTION
php doesn't always live in /usr/bin - better to use env.